### PR TITLE
Use batch mode so it doesn't wait for answer on setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,7 +189,7 @@ class gerrit (
 
   exec {
     'install_gerrit':
-      command => "java -jar ${source} init -d ${target}",
+      command => "java -jar ${source} init -d ${target} --batch",
       creates => "${target}/bin/gerrit.sh",
       user    => $user,
       path    => $::path,
@@ -197,7 +197,7 @@ class gerrit (
 
   exec {
     'reload_gerrit':
-      command     => "java -jar ${target}/bin/gerrit.war init -d ${target}",
+      command     => "java -jar ${target}/bin/gerrit.war init -d ${target} --batch",
       refreshonly => true,
       user        => $user,
       path        => $::path,


### PR DESCRIPTION
When using `gerrit.war` do it in batch mode (`--batch`) so it doesn't fail on waiting for an answer