### PR TITLE
Future parser fixes.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@ define gerrit::config(
   $file   = "${gerrit::target}/etc/gerrit.config"
 ){
 
-  if type($value) == 'array' {
+  if is_array($value) {
     # Check if the existing value in the config is set to exactly the right
     # combination of characters.  We do this by using a gross perl one-liner to
     # compare stdout from git-config with what puppet thinks should be the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,14 +230,14 @@ class gerrit (
     package{
       $java_package:
         ensure => installed,
-    } -> Exec ['install_gerrit']
+    } -> Exec['install_gerrit']
   }
 
   if $install_java_mysql {
     package{
       $mysql_java_package:
         ensure  => installed,
-        require => Exec ['install_gerrit'],
+        require => Exec['install_gerrit'],
     } ->
     file {
       "${target}/lib/mysql-connector-java.jar" :
@@ -250,7 +250,7 @@ class gerrit (
     package{
       $git_package:
         ensure => installed,
-    } -> Exec ['install_gerrit']
+    } -> Exec['install_gerrit']
   }
 
   exec {
@@ -279,7 +279,7 @@ class gerrit (
         hasstatus => false,
         pattern   => 'GerritCodeReview',
         provider  => 'base',
-        require   => Exec ['install_gerrit'],
+        require   => Exec['install_gerrit'],
     }
   }
 


### PR DESCRIPTION
With the Puppet future parser it's not valid to have a space between the
class being referenced and the name of the reference.